### PR TITLE
"name" field support for hkube-core repos

### DIFF
--- a/scripts/getVersions.js
+++ b/scripts/getVersions.js
@@ -39,9 +39,10 @@ const paginationHelper = (github, method, options) => {
     return github.paginate(method.endpoint.merge(options))
 }
 
-const getRepoPackageNames = async (github,options) => {
+const getRepoPackageName = async (github,options) => {
     let jsonMetaData = {};
-    const contents = await github.repos.getContents(options);
+    let mergedOptions = {...options,path:"package.json"};
+    const contents = await github.repos.getContents(mergedOptions);
     if (contents) {
         const packageJsonContent = Buffer.from(contents.data.content, 'base64').toString();
         try {
@@ -81,7 +82,7 @@ const getRestVersions = async (github) => {
             return bToCompare - aToCompare;
         })
         //get package.json contents and use "name" field if it exists, instead of repository name.
-        const jsonMetaData = await getRepoPackageNames(github, { owner: HKUBE, repo: repo.name , path: "package.json"});
+        const jsonMetaData = await getRepoPackageName(github, { owner: HKUBE, repo: repo.name });
         const versionTag = tagNames[0];
         if (!versionTag) {
             console.error(`project ${repo.name} has no tags of version ${requiredVersion}`)


### PR DESCRIPTION
added name replacement if hkube-core repo has "name" field in package.json, by fetching it, while in the proccess of building version.json

part of the kube-HPC/hkube#1684 issue

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/release-manager/46)
<!-- Reviewable:end -->
